### PR TITLE
MTLEXTRuntimeExtensions.m: Fix static analysis error.

### DIFF
--- a/Mantle/extobjc/MTLEXTRuntimeExtensions.m
+++ b/Mantle/extobjc/MTLEXTRuntimeExtensions.m
@@ -55,7 +55,7 @@ mtl_propertyAttributes *mtl_copyPropertyAttributes (objc_property_t property) {
 
         if (!next) {
             fprintf(stderr, "ERROR: Could not read class name in attribute string \"%s\" for property %s\n", attrString, property_getName(property));
-            return NULL;
+            goto errorOut;
         }
 
         if (className != next) {


### PR DESCRIPTION
Same as in libextobjc.