### PR TITLE
MTLModel+Difference: handle nil and incompatible MTLModel argument.

### DIFF
--- a/Mantle/MTLModel+Difference.h
+++ b/Mantle/MTLModel+Difference.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// @note per convention the receiver is to be treated as the "expected",
 /// while the argument object is the "actual".
-- (NSArray<NSString *> *)differenceFrom:(id)object;
+- (NSArray<NSString *> *)differenceFrom:(nullable id)object;
 
 @end
 

--- a/Mantle/MTLModel+Difference.m
+++ b/Mantle/MTLModel+Difference.m
@@ -7,11 +7,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation MTLModel (Difference)
 
-- (NSArray<NSString *> *)differenceFrom:(id)object {
+- (NSArray<NSString *> *)differenceFrom:(nullable id)object {
   MTLModel *actual = (MTLModel *)object;
 
-  NSAssert2([object isKindOfClass:self.class], @"Expected object of type %@, got : %@",
-            self.class, [object class]);
+  if (!actual) {
+    return @[
+      [NSString stringWithFormat:@"Expected: object of type %@, got: nil", NSStringFromClass([self class])]
+    ];
+  }
+
+  if (![[actual class] isEqual:[self class]]) {
+    return @[
+      [NSString stringWithFormat:@"Expected: object of type %@, got: %@",
+       NSStringFromClass([self class]), NSStringFromClass([object class])]
+    ];
+  }
 
   NSMutableArray<NSString *> *differences = [NSMutableArray array];
   for (NSString *key in self.class.propertyKeys) {
@@ -34,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
   }
 
-  return differences.copy;
+  return differences;
 }
 
 @end

--- a/MantleTests/MTLModelDifferenceSpec.m
+++ b/MantleTests/MTLModelDifferenceSpec.m
@@ -10,10 +10,22 @@
 
 QuickSpecBegin(MTLModelDifferenceSpec)
 
-it(@"should raise on mismatching argument type", ^{
+it(@"should return message about expected type", ^{
   MTLTestModel *model = [[MTLTestModel alloc] init];
   NSAssert(model, @"model must be non nil");
-  expect([model differenceFrom:@1]).to(raiseException());
+  NSArray *difference = [model differenceFrom:nil];
+  expect(difference).to(equal(@[
+    @"Expected: object of type MTLTestModel, got: nil"
+  ]));
+});
+
+it(@"should return mismatching argument type message for argument of different type", ^{
+  MTLTestModel *model = [[MTLTestModel alloc] init];
+  NSAssert(model, @"model must be non nil");
+  NSArray *difference = [model differenceFrom:@1];
+  expect(difference).to(equal(@[
+    @"Expected: object of type MTLTestModel, got: __NSCFNumber"
+  ]));
 });
 
 it(@"should compute different fields", ^{


### PR DESCRIPTION
Raising from differenceFrom has negative effect of disrupting tests and
makes getting to the mismatch harder. Therefore returning a descriptive
message for each edge case.
